### PR TITLE
Switch macOS CI to ARM arch

### DIFF
--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -154,7 +154,8 @@ rspec_task:
 
       test_script: bundle exec rspec
 
-      <<: *unix_codecov
+      ## https://github.com/codecov/uploader/issues/523#issuecomment-1318842102
+      # <<: *unix_codecov
 
     - windows_container:
         image: cirrusci/windowsservercore:2019

--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -135,7 +135,7 @@ rspec_task:
       <<: *unix_codecov
 
     - macos_instance:
-        image: big-sur-base
+        image: ghcr.io/cirruslabs/macos-ventura-base:latest
 
       env:
         PATH: "/usr/local/opt/ruby/bin:$PATH"


### PR DESCRIPTION
x86 is no longer supported by Cirrus CI.